### PR TITLE
Add OpenShift deployment support with NIM Operator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Navigate to the [deploy](deploy) directory to learn how to start up the NIMs.
 
 Follow the instructions in the [protein-design-chart](protein-design-chart) directory and deploy the Helm chart
 
+## Deploy on OpenShift
+
+To deploy on Red Hat OpenShift AI with the NIM Operator:
+
+```bash
+cd protein-design-chart/
+helm install protein-design . \
+  -f values.yaml \
+  -f values-openshift.yaml \
+  -n protein-design
+```
+
+The OpenShift overlay enables Routes for external access, creates a custom SCC to handle
+large NIM model volumes, and uses the NIM Operator (NIMCache + NIMService) for automated
+model lifecycle management.
+See [docs/deploy-openshift.md](docs/deploy-openshift.md) for the full deployment guide,
+prerequisites, and troubleshooting.
+
 ## Notebook
 
 An example of how to call each protein binder design step is located in [src/protein-binder-design.ipynb](src/protein-binder-design.ipynb)

--- a/docs/deploy-openshift.md
+++ b/docs/deploy-openshift.md
@@ -1,0 +1,494 @@
+# Deploying Protein Binder Design on Red Hat OpenShift AI
+
+## What We're Deploying
+
+The NVIDIA BioNeMo Blueprint for Protein Binder Design runs four NIM microservices that
+together form an _in silico_ protein binder design pipeline:
+
+| Component | Image | GPU | Port | Purpose |
+|-----------|-------|-----|------|---------|
+| AlphaFold2 | `nvcr.io/nim/deepmind/alphafold2:2.1` | 1 | 8081 | Predict monomer structure from amino acid sequence |
+| RFDiffusion | `nvcr.io/nim/ipd/rfdiffusion:2.0` | 1 | 8082 | Generate protein binder backbones via diffusion |
+| ProteinMPNN | `nvcr.io/nim/ipd/proteinmpnn:1.0` | 1 | 8083 | Design amino acid sequences for generated backbones |
+| AlphaFold2-Multimer | `nvcr.io/nim/deepmind/alphafold2-multimer:2.1` | 1 | 8084 | Predict multimer structure of binder + target complex |
+
+**Data flow:** Target sequence &rarr; AlphaFold2 (structure) &rarr; RFDiffusion (binder backbone)
+&rarr; ProteinMPNN (binder sequence) &rarr; AlphaFold2-Multimer (complex structure) &rarr; PDB output
+
+**Total resources:** 4 pods, 4 GPUs (minimum), ~1.3 TB model storage.
+
+### NIM Operator Components
+
+When deployed with the NIM Operator (recommended on OpenShift), each NIM is managed as a
+pair of custom resources:
+
+- **NIMCache** &mdash; downloads and caches the model on a PVC. Annotated with
+  `helm.sh/resource-policy: keep` to survive upgrades and uninstalls.
+- **NIMService** &mdash; runs the inference server, references its NIMCache for model storage,
+  manages replicas, GPU allocation, and health probes.
+
+## Tested Hardware
+
+| Parameter | Value |
+|-----------|-------|
+| Platform | Red Hat OpenShift AI (RHOAI) 4.14+ |
+| GPU nodes | 2+ nodes with NVIDIA A100 80 GB or H100 |
+| GPUs per node | 2+ |
+| Total GPUs | 4 (one per NIM) |
+| CPU | 24+ cores across GPU nodes |
+| RAM | 64 GB+ per GPU node |
+| Storage | 1.5 Ti+ fast NVMe (dynamic provisioning recommended) |
+| API keys | NVIDIA NGC API key |
+
+**Minimum for reproduction:** 4 x NVIDIA L40s / A100 / H100 GPUs, 1.3 TB storage.
+
+## What's Different from Upstream
+
+| Area | Upstream Default | OpenShift Deployment | Impact |
+|------|-----------------|---------------------|--------|
+| Pod management | Raw Deployments | NIM Operator (NIMCache + NIMService) | Automated model download, cache lifecycle |
+| External access | kubectl port-forward | OpenShift Routes with TLS | Production-grade ingress |
+| Volume provisioning | hostPath PV + static PVC | Dynamic PVCs via NIM Operator | No manual PV creation required |
+| Security context | Init container runs as root | anyuid SCC RoleBinding | Compatible with OpenShift SCC |
+| Probe delays | 3600–21600 s initialDelay | startupProbe 120 s + failureThreshold | Faster failure detection |
+
+## Prerequisites
+
+### CLI Tools
+
+- `oc` (OpenShift CLI) v4.14+
+- `helm` v3.12+
+
+### Cluster Requirements
+
+- OpenShift 4.14+ with NVIDIA GPU Operator installed
+- NIM Operator installed (provides `apps.nvidia.com/v1alpha1` API)
+- At least 4 available GPUs
+
+### Verify GPU Availability
+
+```bash
+oc get nodes -l nvidia.com/gpu.present=true -o custom-columns=\
+NAME:.metadata.name,\
+GPUS:.status.capacity.nvidia\.com/gpu,\
+ALLOCATABLE:.status.allocatable.nvidia\.com/gpu
+```
+
+### Resource Requirements
+
+| Resource | Per NIM | Total (4 NIMs) |
+|----------|---------|----------------|
+| GPU | 1 | 4 |
+| Model storage | 100–500 Gi | ~1.5 Ti |
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NGC_API_KEY` | Yes | — | NGC API key for image pulls and model downloads |
+
+### OpenShift Block (`openshift:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `openshift.enabled` | `false` | Master toggle for all OpenShift resources |
+| `openshift.routes.<nim>.enabled` | `false` | Create a Route for the named NIM service |
+| `openshift.routes.<nim>.host` | `""` | Hostname (auto-generated if empty) |
+| `openshift.routes.<nim>.tls.termination` | `edge` | TLS termination strategy |
+| `openshift.scc.create` | `false` | Create anyuid SCC RoleBinding |
+
+### NIM Operator Block (`nimOperator:`)
+
+Each NIM (alphafold2, rfdiffusion, proteinmpnn, alphafold2-multimer) has:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Deploy this NIM via NIM Operator |
+| `replicas` | `1` | Number of inference replicas |
+| `image.repository` | (per NIM) | NGC container image |
+| `image.tag` | (per NIM) | Image version |
+| `resources.limits.nvidia.com/gpu` | `1` | GPU allocation |
+| `storage.pvc.size` | `100–500Gi` | Model cache PVC size |
+| `storage.pvc.storageClass` | `""` | StorageClass (uses cluster default if empty) |
+| `expose.service.port` | `8081–8084` | Service port |
+
+## Deployment
+
+### 1. Create Namespace
+
+```bash
+oc new-project protein-design
+```
+
+### 2. Create NGC Secrets
+
+The NGC registry secret must carry Helm ownership labels so `helm install` can adopt it:
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+
+oc create secret docker-registry ngc-secret-protein-design \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}" \
+  -n protein-design
+
+oc label secret ngc-secret-protein-design \
+  app.kubernetes.io/managed-by=Helm -n protein-design
+oc annotate secret ngc-secret-protein-design \
+  meta.helm.sh/release-name=protein-design \
+  meta.helm.sh/release-namespace=protein-design -n protein-design
+```
+
+Create the NGC API secret for the NIM Operator:
+
+```bash
+oc create secret generic ngc-api \
+  --from-literal=NGC_API_KEY="${NGC_API_KEY}" \
+  -n protein-design
+
+oc label secret ngc-api \
+  app.kubernetes.io/managed-by=Helm -n protein-design
+oc annotate secret ngc-api \
+  meta.helm.sh/release-name=protein-design \
+  meta.helm.sh/release-namespace=protein-design -n protein-design
+```
+
+Create the NGC registry key secret referenced by Deployment env vars:
+
+```bash
+oc create secret generic ngc-registry-secret \
+  --from-literal=NGC_REGISTRY_KEY="${NGC_API_KEY}" \
+  -n protein-design
+
+oc label secret ngc-registry-secret \
+  app.kubernetes.io/managed-by=Helm -n protein-design
+oc annotate secret ngc-registry-secret \
+  meta.helm.sh/release-name=protein-design \
+  meta.helm.sh/release-namespace=protein-design -n protein-design
+```
+
+### 3. Install the Chart
+
+```bash
+cd protein-design-chart/
+
+helm install protein-design . \
+  -f values.yaml \
+  -f values-openshift.yaml \
+  -n protein-design
+```
+
+This creates:
+- 4 NIMCache resources (one per NIM — triggers model download)
+- 4 NIMService resources (one per NIM — runs inference after cache is ready)
+- 4 OpenShift Routes (edge TLS termination)
+- 1 RoleBinding granting anyuid SCC to the default ServiceAccount
+- Standard Deployments are scaled to 0 (`replicaCount: 0` in overlay)
+
+### 4. Monitor Model Downloads
+
+NIMCache resources download models from NGC. This can take 30–60+ minutes per NIM
+depending on network speed and model size (100–500 GB each).
+
+```bash
+oc get nimcache -n protein-design -w
+```
+
+Wait until all caches show `Ready`:
+
+```
+NAME                       STATUS   AGE
+alphafold2-cache           Ready    45m
+rfdiffusion-cache          Ready    38m
+proteinmpnn-cache          Ready    15m
+alphafold2-multimer-cache  Ready    48m
+```
+
+## Verification
+
+### Check All Pods
+
+```bash
+oc get pods -n protein-design
+```
+
+Expected pods (NIM Operator creates these after NIMCache is ready):
+
+```
+NAME                                    READY   STATUS    RESTARTS   AGE
+alphafold2-0                            1/1     Running   0          10m
+rfdiffusion-0                           1/1     Running   0          10m
+proteinmpnn-0                           1/1     Running   0          10m
+alphafold2-multimer-0                   1/1     Running   0          10m
+```
+
+### Check NIMService Status
+
+```bash
+oc get nimservice -n protein-design
+```
+
+### Health Checks
+
+```bash
+for svc in alphafold2 rfdiffusion proteinmpnn alphafold2-multimer; do
+  echo "--- ${svc} ---"
+  oc exec deploy/${svc} -n protein-design -- \
+    curl -s http://localhost:8000/v1/health/ready
+  echo
+done
+```
+
+## Accessing the NIM APIs
+
+Since this blueprint has no frontend UI, the NIM APIs are accessed directly via the
+Jupyter notebook. There are two ways to run the notebook against the OpenShift deployment.
+
+### Option A: RHOAI Workbench (recommended)
+
+Run the notebook inside an RHOAI workbench in the **same namespace** as the NIM services.
+The workbench connects to NIMs via cluster-internal Kubernetes DNS names — no Routes or
+port-forwarding needed.
+
+#### 1. Create the Workbench
+
+In the RHOAI dashboard, create a new workbench in the `protein-design` namespace:
+
+- **Image:** Jupyter minimal or Jupyter data science
+- **Environment variables** (set during workbench creation):
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `DEPLOYMENT_MODE` | `openshift` | Switches notebook to cluster-internal URLs |
+| `NVIDIA_API_KEY` | `<your-ngc-api-key>` | NGC authentication for NIM API calls |
+
+Optional overrides (only needed if your service names differ from the NIM Operator defaults):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ALPHAFOLD2_HOST` | `http://alphafold2` | AlphaFold2 NIMService URL |
+| `RFDIFFUSION_HOST` | `http://rfdiffusion` | RFDiffusion NIMService URL |
+| `PROTEINMPNN_HOST` | `http://proteinmpnn` | ProteinMPNN NIMService URL |
+| `AF2_MULTIMER_HOST` | `http://alphafold2-multimer` | AlphaFold2-Multimer NIMService URL |
+
+If you are using the standard Helm chart Deployments (not NIM Operator), set the host
+variables to match your release name, e.g.:
+
+```
+ALPHAFOLD2_HOST=http://<release>-protein-design-chart-alphafold2
+```
+
+#### 2. Upload and Run the Notebook
+
+Upload `src/protein-binder-design.ipynb` to the workbench and run all cells. The notebook
+automatically detects `DEPLOYMENT_MODE=openshift` and uses cluster-internal URLs:
+
+```
+OpenShift/RHOAI Mode - Using Helm-deployed NIM services
+
+Service URLs:
+  ALPHAFOLD2: http://alphafold2:8081
+  RFDIFFUSION: http://rfdiffusion:8082
+  PROTEINMPNN: http://proteinmpnn:8083
+  AF2_MULTIMER: http://alphafold2-multimer:8084
+```
+
+The comprehensive health check cell verifies all four NIMs are reachable before the
+pipeline starts.
+
+#### 3. Fallback: Set DEPLOYMENT_MODE in the Notebook
+
+If you forgot to set `DEPLOYMENT_MODE` when creating the workbench, uncomment this line
+in the NIM configuration cell:
+
+```python
+os.environ['DEPLOYMENT_MODE'] = 'openshift'
+```
+
+### Option B: External Access via Routes or Port-Forwarding
+
+For running the notebook on your local machine against the OpenShift cluster:
+
+**Using Routes:**
+
+```bash
+oc get routes -n protein-design
+```
+
+Update the NIM host environment variables to use Route hostnames (with `https://` prefix
+and port `443`).
+
+**Using port-forward:**
+
+```bash
+oc port-forward svc/protein-design-protein-design-chart-alphafold2 8081:8081 -n protein-design &
+oc port-forward svc/protein-design-protein-design-chart-rfdiffusion 8082:8082 -n protein-design &
+oc port-forward svc/protein-design-protein-design-chart-proteinmpnn 8083:8083 -n protein-design &
+oc port-forward svc/protein-design-protein-design-chart-alphafold2multimer 8084:8084 -n protein-design &
+```
+
+Then run the notebook in local mode (default, no `DEPLOYMENT_MODE` needed):
+
+```bash
+cd src/
+jupyter notebook
+```
+
+## Testing the Pipeline End-to-End
+
+Pods being `Running` does not mean the pipeline works. Validate with an actual protein
+sequence through all four steps.
+
+### 1. Verify Each NIM Responds
+
+```bash
+ALPHAFOLD2_URL="http://localhost:8081"
+RFDIFFUSION_URL="http://localhost:8082"
+PROTEINMPNN_URL="http://localhost:8083"
+MULTIMER_URL="http://localhost:8084"
+
+for url in $ALPHAFOLD2_URL $RFDIFFUSION_URL $PROTEINMPNN_URL $MULTIMER_URL; do
+  echo "--- ${url} ---"
+  curl -s "${url}/v1/health/ready"
+  echo
+done
+```
+
+### 2. Run the Notebook
+
+Open `src/protein-binder-design.ipynb` and execute all cells. The notebook:
+
+1. Sends a target protein sequence to AlphaFold2 for structure prediction
+2. Passes the structure to RFDiffusion for binder backbone generation
+3. Sends the backbone to ProteinMPNN for sequence design
+4. Submits the binder + target to AlphaFold2-Multimer for complex structure prediction
+5. Outputs PDB files of the predicted multimer structures
+
+A successful run produces PDB output in the final cells.
+
+## OpenShift-Specific Challenges and Solutions
+
+### 1. Init Container Requires Root (anyuid SCC)
+
+**What happened:** The AlphaFold2 Deployment includes an init container
+(`volume-permissions`) that runs with `runAsUser: 0` to `mkdir` and `chmod 777` the model
+cache directory. OpenShift's default `restricted` SCC blocks this.
+
+**Error:** `Error: container has runAsNonRoot and image has non-numeric user`
+
+**Services affected:** AlphaFold2 (Deployment path only; NIM Operator path does not use
+the init container).
+
+**Fix:** The `openshift.yaml` template creates a RoleBinding granting `anyuid` SCC to the
+`default` ServiceAccount when `openshift.scc.create: true`. This is set in the overlay.
+
+### 2. hostPath PV Not Permitted on OpenShift
+
+**What happened:** The upstream chart creates a `hostPath`-based PersistentVolume
+(`pv.yaml`). OpenShift clusters typically restrict hostPath to privileged pods.
+
+**Error:** PVC stays `Pending`; PV cannot bind.
+
+**Services affected:** All four NIMs (they share a single PVC).
+
+**Fix:** When using the NIM Operator path, each NIMCache creates its own dynamically
+provisioned PVC. Set `persistence.storageClass` to your cluster's StorageClass (e.g.
+`gp3-csi`, `ocs-storagecluster-cephfs`). The static hostPath PV/PVC are unused when
+`replicaCount: 0`.
+
+### 3. Large Model Downloads and Probe Timeouts
+
+**What happened:** AlphaFold2 and AlphaFold2-Multimer models are hundreds of GB. The
+upstream chart uses `initialDelaySeconds: 21600` (6 hours) on liveness/readiness probes
+to accommodate this.
+
+**Services affected:** AlphaFold2, AlphaFold2-Multimer.
+
+**Fix:** The NIM Operator separates model downloading (NIMCache) from serving (NIMService).
+The NIMService only starts after the cache is ready, so startup probes use reasonable
+values (120 s initial delay, 30 s period, high failureThreshold). This improves failure
+detection without risking premature termination.
+
+### 4. GPU Scheduling and Tolerations
+
+**What happened:** GPU nodes in OpenShift clusters often carry taints
+(`nvidia.com/gpu=present:NoSchedule`) to prevent non-GPU workloads from landing on them.
+
+**Services affected:** All four NIMs.
+
+**Fix:** Add tolerations in the values overlay or per-NIM config:
+
+```yaml
+nimOperator:
+  alphafold2:
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+```
+
+### 5. Service Type Override for Routes
+
+**What happened:** The upstream chart defaults to `ClusterIP`, which is correct for
+OpenShift Routes. If it had used `NodePort` or `LoadBalancer`, Routes would conflict.
+
+**Services affected:** All four NIMs.
+
+**Fix:** The overlay explicitly sets `service.type: ClusterIP` and creates Routes for
+external access. No action needed if the upstream default was already `ClusterIP`, but
+the overlay makes the intent explicit.
+
+### 6. NGC Secret Ownership by Helm
+
+**What happened:** If NGC secrets are created with `oc create secret` before `helm install`,
+Helm refuses to adopt them during install or upgrade.
+
+**Error:** `Error: rendered manifests contain a resource that already exists`
+
+**Services affected:** All (secret is shared).
+
+**Fix:** Pre-label secrets with Helm ownership metadata before install (see
+[Deployment > Create NGC Secrets](#2-create-ngc-secrets)):
+
+```bash
+oc label secret <name> app.kubernetes.io/managed-by=Helm
+oc annotate secret <name> \
+  meta.helm.sh/release-name=protein-design \
+  meta.helm.sh/release-namespace=protein-design
+```
+
+### 7. TOKENIZERS_PARALLELISM Race Condition
+
+**What happened:** NIM containers that use HuggingFace tokenizers may hit a thread pool
+race condition, causing startup failures or intermittent crashes.
+
+**Services affected:** Potentially all NIMs.
+
+**Fix:** Set `TOKENIZERS_PARALLELISM=false` in each NIM's env block. The
+`values-openshift.yaml` overlay includes this as a preventive measure.
+
+## Cleanup
+
+Remove the Helm release:
+
+```bash
+helm uninstall protein-design -n protein-design
+```
+
+**Important:** NIMCache PVCs persist after uninstall due to
+`helm.sh/resource-policy: keep`. This is intentional — model downloads are expensive
+(100–500 GB each). To remove them manually:
+
+```bash
+oc delete nimcache --all -n protein-design
+oc delete pvc -l app.kubernetes.io/managed-by=nim-operator -n protein-design
+```
+
+Delete the namespace (removes all remaining resources):
+
+```bash
+oc delete project protein-design
+```

--- a/protein-design-chart/templates/nim-alphafold2-multimer.yaml
+++ b/protein-design-chart/templates/nim-alphafold2-multimer.yaml
@@ -1,0 +1,66 @@
+{{- $nim := index .Values.nimOperator "alphafold2-multimer" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "500Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/protein-design-chart/templates/nim-alphafold2.yaml
+++ b/protein-design-chart/templates/nim-alphafold2.yaml
@@ -1,0 +1,66 @@
+{{- $nim := index .Values.nimOperator "alphafold2" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "500Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/protein-design-chart/templates/nim-proteinmpnn.yaml
+++ b/protein-design-chart/templates/nim-proteinmpnn.yaml
@@ -1,0 +1,66 @@
+{{- $nim := index .Values.nimOperator "proteinmpnn" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "100Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/protein-design-chart/templates/nim-rfdiffusion.yaml
+++ b/protein-design-chart/templates/nim-rfdiffusion.yaml
@@ -1,0 +1,66 @@
+{{- $nim := index .Values.nimOperator "rfdiffusion" -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.imagePullSecret.name }}
+      authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "350Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.imagePullSecret.name }}
+  authSecret: {{ .Values.ngcApiSecret.name }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/protein-design-chart/templates/openshift.yaml
+++ b/protein-design-chart/templates/openshift.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.openshift.enabled }}
+{{- $fullName := include "protein-design-chart.fullname" . }}
+{{- $routes := .Values.openshift.routes | default dict }}
+{{- $services := list "alphafold2" "rfdiffusion" "proteinmpnn" "alphafold2multimer" }}
+
+{{- range $serviceName := $services }}
+{{- $routeConfig := dict }}
+{{- if hasKey $routes $serviceName }}
+{{- $routeConfig = index $routes $serviceName }}
+{{- end }}
+{{- if (default false $routeConfig.enabled) }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-{{ $serviceName }}
+  labels:
+    {{- include "protein-design-chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+spec:
+  {{- if $routeConfig.host }}
+  host: {{ $routeConfig.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}-{{ $serviceName }}
+  port:
+    targetPort: {{ $serviceName }}-port
+  {{- with $routeConfig.tls }}
+  tls:
+    termination: {{ .termination | default "edge" }}
+    {{- if .insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .insecureEdgeTerminationPolicy }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.openshift.scc.create }}
+---
+# Custom SCC: identical to "nonroot" but with seLinuxContext: RunAsAny.
+# This prevents the kubelet from recursively relabeling every file on
+# mounted volumes — critical for AlphaFold2's 2TB PVCs with millions of files.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ $fullName }}-nim
+  labels:
+    {{- include "protein-design-chart.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: >-
+      Like nonroot, but skips recursive SELinux relabeling on volume mounts.
+      Required for NIM services with very large cached model PVCs.
+priority: 20
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:default
+  - system:serviceaccount:{{ .Release.Namespace }}:nim-cache-sa
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - system:serviceaccount:{{ $.Release.Namespace }}:{{ $nimVal.service.name }}
+  {{- end }}
+  {{- end }}
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-nim-scc
+  labels:
+    {{- include "protein-design-chart.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ $fullName }}-nim
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: nim-cache-sa
+    namespace: {{ .Release.Namespace }}
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - kind: ServiceAccount
+    name: {{ $nimVal.service.name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/protein-design-chart/values-openshift.yaml
+++ b/protein-design-chart/values-openshift.yaml
@@ -1,180 +1,86 @@
-# Default values for protein-design-chart.
-
-replicaCount: 1
-
-alphafold2:
-  containerName: alphafold2
-  containerPort: 8000
-  repository: nvcr.io/nim/deepmind/alphafold2
-  tag: "2.1"
-  pullPolicy: Always
-  cacheFolder: /opt/nim/.cache
-  servicePort: 8081
-
-rfdiffusion:
-  containerName: rfdiffusion
-  containerPort: 8000
-  repository: nvcr.io/nim/ipd/rfdiffusion
-  tag: "2.0"
-  pullPolicy: Always
-  cacheFolder: /home/nvs/.cache
-  servicePort: 8082
-
-proteinmpnn:
-  containerName: proteinmpnn
-  containerPort: 8000
-  repository: nvcr.io/nim/ipd/proteinmpnn
-  tag: "1.0"
-  pullPolicy: Always
-  cacheFolder: /home/nvs/.cache
-  servicePort: 8083
-
-alphafold2multimer:
-  containerName: alphafold2-multimer
-  containerPort: 8000
-  repository: nvcr.io/nim/deepmind/alphafold2-multimer
-  tag: "2.1"
-  pullPolicy: Always
-  cacheFolder: /opt/nim/.cache
-  servicePort: 8084
-
-imagePullSecret:
-  registry: "nvcr.io"
-  name: "ngc-secret-protein-design"
-  create: true
-  username: '$oauthtoken'
-  secretName: ngc-registry-secret
-  secretKey: NGC_REGISTRY_KEY
-
-service:
-  type: ClusterIP
-
-nameOverride: ""
-fullnameOverride: ""
-
-# serviceAccount:
-#   # Specifies whether a service account should be created
-#   create: true
-#   # Annotations to add to the service account
-#   annotations: {}
-#   # The name of the service account to use.
-#   # If not set and create is true, a name is generated using the fullname template
-#   name: ""
-
-podAnnotations: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    nvidia.com/gpu: 1
-  requests:
-    nvidia.com/gpu: 1
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-persistence:
-  enabled: true
-  existingClaim: ""
-  storageClass: standard
-  accessMode: ReadWriteMany
-  hostPath: /data/nim
-  size: 1.5Ti
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
+# values-openshift.yaml — OpenShift overlay for the Protein Design Blueprint.
+#
+# Usage:
+#   helm install protein-design . \
+#     -f values.yaml \
+#     -f values-openshift.yaml \
+#     --set imagePullSecret.secretName=ngc-registry-secret \
+#     -n protein-design
+#
+# This file enables OpenShift-specific resources (Routes, SCC RoleBindings)
+# and switches from standard Deployments to NIM Operator managed services.
+# Cluster-specific values (namespace, NGC keys) should be passed via --set.
 
 # ---------------------------------------------------------------------------
-# OpenShift support (disabled by default — zero impact on vanilla Kubernetes)
+# Shorten the chart fullname to avoid exceeding the 63-character DNS label
+# limit on auto-generated Route hostnames.
+# ---------------------------------------------------------------------------
+fullnameOverride: "protein-design"
+
+# ---------------------------------------------------------------------------
+# Disable standard Deployments — NIM Operator manages the NIM lifecycle.
+# ---------------------------------------------------------------------------
+replicaCount: 0
+
+# ---------------------------------------------------------------------------
+# OpenShift features
 # ---------------------------------------------------------------------------
 openshift:
-  enabled: false
+  enabled: true
 
   routes:
     alphafold2:
-      enabled: false
-      host: ""
+      enabled: true
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
     rfdiffusion:
-      enabled: false
-      host: ""
+      enabled: true
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
     proteinmpnn:
-      enabled: false
-      host: ""
+      enabled: true
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
     alphafold2multimer:
-      enabled: false
-      host: ""
+      enabled: true
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
 
-  # Creates a custom SCC (like "nonroot" but with seLinuxContext: RunAsAny)
-  # to prevent recursive SELinux relabeling on large NIM model PVCs.
+  # Creates a custom SCC (protein-design-nim) that is like "nonroot" but
+  # with seLinuxContext: RunAsAny.  This prevents the kubelet from
+  # recursively relabeling every file on mounted volumes — critical for
+  # AlphaFold2's 2TB PVCs with millions of genomic database files.
   scc:
-    create: false
-    priority: 10
+    create: true
 
 # ---------------------------------------------------------------------------
-# NGC API secret used by the NIM Operator for model downloads.
-# Must contain a key named NGC_API_KEY.
+# Override service type — Routes handle external access on OpenShift.
 # ---------------------------------------------------------------------------
-ngcApiSecret:
-  name: "ngc-api"
+service:
+  type: ClusterIP
 
 # ---------------------------------------------------------------------------
-# NIM Operator integration (disabled by default).
-# When enabled AND the NIM Operator CRD is present on the cluster, NIMCache +
-# NIMService resources are created instead of raw Deployments.
-# Set replicaCount: 0 in your overlay to disable the standard Deployments.
+# Persistence — OpenShift dynamic provisioning (no hostPath PV needed).
+# Set storageClass to match your cluster (e.g. "gp3-csi", "ocs-storagecluster-cephfs").
+# ---------------------------------------------------------------------------
+persistence:
+  enabled: true
+  storageClass: "gp3-csi"
+  accessMode: ReadWriteMany
+  size: 1.5Ti
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration — each NIM gets a NIMCache + NIMService pair.
+# The NIM Operator handles model downloading, caching, and GPU scheduling.
+# Requires: NIM Operator installed, NGC image-pull and API secrets in namespace.
 # ---------------------------------------------------------------------------
 nimOperator:
   alphafold2:
-    enabled: false
+    enabled: true
     replicas: 1
     service:
       name: "alphafold2"
@@ -192,14 +98,26 @@ nimOperator:
         create: true
         size: "2000Gi"
         volumeAccessMode: ReadWriteOnce
-        storageClass: ""
+        storageClass: "gp3-csi"
     nodeSelector: {}
-    tolerations: []
+    # Tolerate GPU node taints so cache and service pods can schedule.
+    # Adjust keys to match your cluster's GPU node taints.
+    tolerations:
+      - key: g6-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: p4-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
     env:
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_CACHE_PATH
         value: "/model-store"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
     expose:
       service:
         name: http
@@ -216,7 +134,7 @@ nimOperator:
         failureThreshold: 720
 
   rfdiffusion:
-    enabled: false
+    enabled: true
     replicas: 1
     service:
       name: "rfdiffusion"
@@ -236,17 +154,33 @@ nimOperator:
         volumeAccessMode: ReadWriteOnce
         storageClass: ""
     nodeSelector: {}
-    tolerations: []
+    tolerations:
+      - key: g6-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: p4-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
     env:
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_CACHE_PATH
         value: "/home/nvs/.cache/nim/models"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
     expose:
       service:
         name: http
         type: ClusterIP
         port: 8000
+    # RFDiffusion compiles TensorRT engines on FIRST-EVER start for a given
+    # GPU architecture.  This one-time build can take 2-4 hours.  The compiled
+    # engines are cached in ephemeral container storage, so subsequent pod
+    # restarts on the same node reuse them — but a rollout (new ReplicaSet)
+    # loses the cache and forces a full rebuild.
+    # failureThreshold: 720 × periodSeconds: 30 = 6 hours headroom.
     startupProbe:
       enabled: true
       probe:
@@ -255,10 +189,10 @@ nimOperator:
           port: 8000
         initialDelaySeconds: 120
         periodSeconds: 30
-        failureThreshold: 120
+        failureThreshold: 720
 
   proteinmpnn:
-    enabled: false
+    enabled: true
     replicas: 1
     service:
       name: "proteinmpnn"
@@ -278,12 +212,22 @@ nimOperator:
         volumeAccessMode: ReadWriteOnce
         storageClass: ""
     nodeSelector: {}
-    tolerations: []
+    tolerations:
+      - key: g6-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: p4-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
     env:
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_CACHE_PATH
         value: "/home/nvs/.cache/nim/models"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
     expose:
       service:
         name: http
@@ -300,7 +244,7 @@ nimOperator:
         failureThreshold: 120
 
   alphafold2-multimer:
-    enabled: false
+    enabled: true
     replicas: 1
     service:
       name: "alphafold2-multimer"
@@ -318,14 +262,24 @@ nimOperator:
         create: true
         size: "2000Gi"
         volumeAccessMode: ReadWriteOnce
-        storageClass: ""
+        storageClass: "gp3-csi"
     nodeSelector: {}
-    tolerations: []
+    tolerations:
+      - key: g6-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: p4-gpu
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
     env:
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_CACHE_PATH
         value: "/model-store"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
     expose:
       service:
         name: http
@@ -340,4 +294,3 @@ nimOperator:
         initialDelaySeconds: 120
         periodSeconds: 30
         failureThreshold: 360
-

--- a/src/protein-binder-design.ipynb
+++ b/src/protein-binder-design.ipynb
@@ -24,6 +24,8 @@
    "source": [
     "### Getting started with NIMs\n",
     "\n",
+    "#### Local deployment (Docker Compose)\n",
+    "\n",
     "Navigate to the `deploy` directory and follow the instructions in the `README.md` to run docker compose:\n",
     "\n",
     "```bash\n",
@@ -38,13 +40,43 @@
     "curl localhost:8082/v1/health/ready\n",
     "curl localhost:8083/v1/health/ready\n",
     "curl localhost:8084/v1/health/ready\n",
-    "```"
+    "```\n",
+    "\n",
+    "#### OpenShift / RHOAI deployment\n",
+    "\n",
+    "When running this notebook in an **RHOAI workbench**, the NIM services are already deployed on the cluster via Helm. Set the environment variable `DEPLOYMENT_MODE=openshift` when creating the workbench (or uncomment the fallback line in the configuration cell below). The notebook will automatically switch from `localhost` to cluster-internal Kubernetes DNS names.\n",
+    "\n",
+    "See [docs/deploy-openshift.md](../docs/deploy-openshift.md) for the full deployment guide."
    ]
   },
   {
    "cell_type": "markdown",
-   "source": "### Jupyter Server Configuration\n\nThis workflow generates large PDB output strings that can exceed Jupyter's default IOPub data rate limit. If you encounter the following error when printing results:\n\n```\nIOPub data rate exceeded.\nThe Jupyter server will temporarily stop sending output\nto the client in order to avoid crashing it.\nTo change this limit, set the config variable\n`--ServerApp.iopub_data_rate_limit`.\n```\n\nStart your Jupyter server with an increased data rate limit:\n\n```bash\njupyter lab --ServerApp.iopub_data_rate_limit=10000000\n```\n\nOr add it to your Jupyter configuration file (`~/.jupyter/jupyter_server_config.py`):\n\n```python\nc.ServerApp.iopub_data_rate_limit = 10000000\n```",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Jupyter Server Configuration\n",
+    "\n",
+    "This workflow generates large PDB output strings that can exceed Jupyter's default IOPub data rate limit. If you encounter the following error when printing results:\n",
+    "\n",
+    "```\n",
+    "IOPub data rate exceeded.\n",
+    "The Jupyter server will temporarily stop sending output\n",
+    "to the client in order to avoid crashing it.\n",
+    "To change this limit, set the config variable\n",
+    "`--ServerApp.iopub_data_rate_limit`.\n",
+    "```\n",
+    "\n",
+    "Start your Jupyter server with an increased data rate limit:\n",
+    "\n",
+    "```bash\n",
+    "jupyter lab --ServerApp.iopub_data_rate_limit=10000000\n",
+    "```\n",
+    "\n",
+    "Or add it to your Jupyter configuration file (`~/.jupyter/jupyter_server_config.py`):\n",
+    "\n",
+    "```python\n",
+    "c.ServerApp.iopub_data_rate_limit = 10000000\n",
+    "```"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -55,18 +87,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "! pip install requests"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",
@@ -74,7 +104,9 @@
     "from enum import StrEnum, Enum\n",
     "from typing import Tuple, Dict, Any, List\n",
     "from pathlib import Path\n"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -92,33 +124,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
    "source": [
     "NVIDIA_API_KEY = os.getenv(\"NVIDIA_API_KEY\") or input(\"Paste Run Key: \")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
    "source": [
     "HEADERS = {\n",
     "    \"Content-Type\": \"application/json\",\n",
     "    \"Authorization\": f\"Bearer {NVIDIA_API_KEY}\",\n",
     "    \"poll-seconds\": \"900\"\n",
     "}"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
    "source": [
-    "NIM_HOST_URL_BASE = \"http://localhost\"\n",
+    "# RECOMMENDED: Set DEPLOYMENT_MODE=openshift when creating your RHOAI workbench.\n",
+    "# FALLBACK: Uncomment the line below if you forgot to set it during creation.\n",
+    "# os.environ['DEPLOYMENT_MODE'] = 'openshift'\n",
+    "\n",
+    "DEPLOYMENT_MODE = os.getenv('DEPLOYMENT_MODE', 'local')\n",
+    "\n",
+    "if DEPLOYMENT_MODE == 'openshift':\n",
+    "    # Cluster-internal K8s DNS names. Defaults match NIM Operator service names\n",
+    "    # from values-openshift.yaml. Override with env vars if using standard Helm\n",
+    "    # chart service names (e.g. ALPHAFOLD2_HOST=http://<release>-protein-design-chart-alphafold2).\n",
+    "    NIM_HOSTS = {\n",
+    "        'ALPHAFOLD2': os.getenv('ALPHAFOLD2_HOST', 'http://alphafold2'),\n",
+    "        'RFDIFFUSION': os.getenv('RFDIFFUSION_HOST', 'http://rfdiffusion'),\n",
+    "        'PROTEINMPNN': os.getenv('PROTEINMPNN_HOST', 'http://proteinmpnn'),\n",
+    "        'AF2_MULTIMER': os.getenv('AF2_MULTIMER_HOST', 'http://alphafold2-multimer'),\n",
+    "    }\n",
+    "    print(\"OpenShift/RHOAI Mode - Using Helm-deployed NIM services\")\n",
+    "else:\n",
+    "    NIM_HOSTS = {name: 'http://localhost' for name in ['ALPHAFOLD2', 'RFDIFFUSION', 'PROTEINMPNN', 'AF2_MULTIMER']}\n",
+    "    print(\"Local Mode - Using localhost (deploy with docker compose first)\")\n",
+    "\n",
+    "NIM_HOST_URL_BASE = NIM_HOSTS['ALPHAFOLD2']\n",
     "\n",
     "class NIM_PORTS(Enum):\n",
     "    ALPHAFOLD2_PORT = 8081\n",
@@ -126,28 +177,59 @@
     "    PROTEINMPNN_PORT = 8083\n",
     "    AF2_MULTIMER_PORT = 8084\n",
     "\n",
+    "_OCP_PORT = 8000\n",
+    "if DEPLOYMENT_MODE == 'openshift':\n",
+    "    NIM_PORT_TO_BASE_URL = {\n",
+    "        NIM_PORTS.ALPHAFOLD2_PORT.value: f\"{NIM_HOSTS['ALPHAFOLD2']}:{_OCP_PORT}\",\n",
+    "        NIM_PORTS.RFDIFFUSION_PORT.value: f\"{NIM_HOSTS['RFDIFFUSION']}:{_OCP_PORT}\",\n",
+    "        NIM_PORTS.PROTEINMPNN_PORT.value: f\"{NIM_HOSTS['PROTEINMPNN']}:{_OCP_PORT}\",\n",
+    "        NIM_PORTS.AF2_MULTIMER_PORT.value: f\"{NIM_HOSTS['AF2_MULTIMER']}:{_OCP_PORT}\",\n",
+    "    }\n",
+    "else:\n",
+    "    NIM_PORT_TO_BASE_URL = {\n",
+    "        NIM_PORTS.ALPHAFOLD2_PORT.value: f\"{NIM_HOSTS['ALPHAFOLD2']}:{NIM_PORTS.ALPHAFOLD2_PORT.value}\",\n",
+    "        NIM_PORTS.RFDIFFUSION_PORT.value: f\"{NIM_HOSTS['RFDIFFUSION']}:{NIM_PORTS.RFDIFFUSION_PORT.value}\",\n",
+    "        NIM_PORTS.PROTEINMPNN_PORT.value: f\"{NIM_HOSTS['PROTEINMPNN']}:{NIM_PORTS.PROTEINMPNN_PORT.value}\",\n",
+    "        NIM_PORTS.AF2_MULTIMER_PORT.value: f\"{NIM_HOSTS['AF2_MULTIMER']}:{NIM_PORTS.AF2_MULTIMER_PORT.value}\",\n",
+    "    }\n",
     "\n",
     "class NIM_ENDPOINTS(StrEnum):\n",
     "    ALPHAFOLD2 = \"protein-structure/alphafold2/predict-structure-from-sequence\"\n",
     "    RFDIFFUSION =  \"biology/ipd/rfdiffusion/generate\"\n",
     "    PROTEINMPNN =  \"biology/ipd/proteinmpnn/predict\"\n",
-    "    AF2_MULTIMER = \"protein-structure/alphafold2/multimer/predict-structure-from-sequences\""
-   ]
+    "    AF2_MULTIMER = \"protein-structure/alphafold2/multimer/predict-structure-from-sequences\"\n",
+    "\n",
+    "print(f\"\\nService URLs:\")\n",
+    "for name in NIM_HOSTS:\n",
+    "    port = getattr(NIM_PORTS, f\"{name}_PORT\").value\n",
+    "    print(f\"  {name}: {NIM_PORT_TO_BASE_URL[port]}\")",
+    "\n",
+    "if DEPLOYMENT_MODE == 'openshift':\n",
+    "    import threading, time as _time\n",
+    "    def _keepalive():\n",
+    "        while True:\n",
+    "            _time.sleep(60)\n",
+    "            print('.', end='', flush=True)\n",
+    "    threading.Thread(target=_keepalive, daemon=True).start()\n",
+    "    print('Keepalive thread started (prints a dot every 60s to prevent connection timeout)')\n"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
    "source": [
     "def query_nim(\n",
     "            payload: Dict[str, Any],\n",
     "            nim_endpoint: str,\n",
     "            headers: Dict[str, str] = HEADERS,\n",
-    "            base_url: str = \"http://localhost\",\n",
+    "            base_url: str = None,\n",
     "            nim_port: int = 8080,\n",
     "            echo: bool = False) -> Tuple[int, Dict]:\n",
-    "    function_url = f\"{base_url}:{nim_port}/{nim_endpoint}\"\n",
+    "    if base_url is None:\n",
+    "        base_url = NIM_PORT_TO_BASE_URL.get(nim_port, f\"{NIM_HOST_URL_BASE}:{nim_port}\")\n",
+    "    function_url = f\"{base_url}/{nim_endpoint}\"\n",
     "    if echo:\n",
     "        print(\"*\"*80)\n",
     "        print(f\"\\tURL: {function_url}\")\n",
@@ -162,13 +244,15 @@
     "        raise Exception(f\"Error: response returned code [{response.status_code}], with text: {response.text}\")\n",
     "\n",
     "def check_nim_readiness(nim_port: NIM_PORTS,\n",
-    "                        base_url: str = NIM_HOST_URL_BASE,\n",
+    "                        base_url: str = None,\n",
     "                        endpoint: str = \"v1/health/ready\") -> bool:\n",
     "    \"\"\"\n",
     "    Return true if a NIM is ready.\n",
     "    \"\"\"\n",
+    "    if base_url is None:\n",
+    "        base_url = NIM_PORT_TO_BASE_URL.get(nim_port, f\"{NIM_HOST_URL_BASE}:{nim_port}\")\n",
     "    try:\n",
-    "        response = requests.get(f\"{base_url}:{nim_port}/{endpoint}\")\n",
+    "        response = requests.get(f\"{base_url}/{endpoint}\")\n",
     "        d = response.json()\n",
     "        if \"status\" in d:\n",
     "            if d[\"status\"] == \"ready\":\n",
@@ -183,14 +267,14 @@
     "    if not pdb.exists() and rcsb_path is not None:\n",
     "        pdb.write_text(requests.get(rcsb_path).text)\n",
     "    lines = filter(lambda line: line.startswith(\"ATOM\"), pdb.read_text().split(\"\\n\"))\n",
-    "    return \"\\n\".join(list(lines))\n"
-   ]
+    "    return \"\\n\".join(list(lines))"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
    "source": [
     "class ExampleRequestParams:\n",
     "    def __init__(self,\n",
@@ -212,7 +296,9 @@
     "        self.sampling_temp = sampling_temp\n",
     "        self.diffusion_steps = diffusion_steps\n",
     "        self.num_seq_per_target = num_seq_per_target"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -227,9 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "example_6vxx = ExampleRequestParams(\n",
     "    target_sequence=\"MGILPSPGMPALLSLVSLLSVLLMGCVAETGTQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHSTQDLFLPFFSNVTWFHAIHVSGTNGTKRFDNPVLPFNDGVYFASTEKSNIIRGWIFGTTLDSKTQSLLIVNNATNVVIKVCEFQFCNDPFLGVYYHKNNKSWMESEFRVYSSANNCTFEYVSQPFLMDLEGKQGNFKNLREFVFKNIDGYFKIYSKHTPINLVRDLPQGFSALEPLVDLPIGINITRFQTLLALHRSYLTPGDSSSGWTAGAAAYYVGYLQPRTFLLKYNENGTITDAVDCALDPLSETKCTLKSFTVEKGIYQTSNFRVQPTESIVRFPNITNLCPFGEVFNATRFASVYAWNRKRISNCVADYSVLYNSASFSTFKCYGVSPTKLNDLCFTNVYADSFVIRGDEVRQIAPGQTGKIADYNYKLPDDFTGCVIAWNSNNLDSKVGGNYNYLYRLFRKSNLKPFERDISTEIYQAGSTPCNGVEGFNCYFPLQSYGFQPTNGVGYQPYRVVVLSFELLHAPATVCGPKKSTNLVKNKCVNFNFNGLTGTGVLTESNKKFLPFQQFGRDIADTTDAVRDPQTLEILDITPCSFGGVSVITPGTNTSNQVAVLYQDVNCTEVPVAIHADQLTPTWRVYSTGSNVFQTRAGCLIGAEHVNNSYECDIPIGAGICASYQTQTNSPSGAGSVASQSIIAYTMSLGAENSVAYSNNSIAIPTNFTISVTTEILPVSMTKTSVDCTMYICGDSTECSNLLLQYGSFCTQLNRALTGIAVEQDKNTQEVFAQVKQIYKTPPIKDFGGFNFSQILPDPSKPSKRSFIEDLLFNKVTLADAGFIKQYGDCLGDIAARDLICAQKFNGLTVLPPLLTDEMIAQYTSALLAGTITSGWTFGAGAALQIPFAMQMAYRFNGIGVTQNVLYENQKLIANQFNSAIGKIQDSLSSTASALGKLQDVVNQNAQALNTLVKQLSSNFGAISSVLNDILSRLDPPEAEVQIDRLITGRLQSLQTYVTQQLIRAAEIRASANLAATKMSECVLGQSKRVDFCGKGYHLMSFPQSAPHGVVFLHVTYVPAQEKNFTTAPAICHDGKAHFPREGVFVSNGTHWFVTQRNFYEPQIITTDNTFVSGNCDVVIGIVNNTVYDPLQPELDSFKEELDKYFKNHTSPDVDLGDISGINASVVNIQKEIDRLNEVAKNLNESLIDLQELGKYEQYIKGSGRENLYFQGGGGSGYIPEAPRDGQAYVRKDGEWVLLSTFLGHHHHHHHH\",\n",
@@ -264,18 +348,20 @@
     "    diffusion_steps=15,\n",
     "    num_seq_per_target=20\n",
     ")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Set the example here to switch example inputs.\n",
     "## Note: Example 6vxx requires a GPU with at least 80GB of VRAM.\n",
     "example = example_5ptn"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -288,43 +374,91 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "def check_all_nims_health(retries=3, delay=10):\n",
+    "    \"\"\"Check health of all NIM services. Retries on failure.\"\"\"\n",
+    "    nims = [\n",
+    "        (\"AlphaFold2\", NIM_PORTS.ALPHAFOLD2_PORT.value),\n",
+    "        (\"RFDiffusion\", NIM_PORTS.RFDIFFUSION_PORT.value),\n",
+    "        (\"ProteinMPNN\", NIM_PORTS.PROTEINMPNN_PORT.value),\n",
+    "        (\"AlphaFold2-Multimer\", NIM_PORTS.AF2_MULTIMER_PORT.value),\n",
+    "    ]\n",
+    "    all_ready = True\n",
+    "    for name, port in nims:\n",
+    "        base_url = NIM_PORT_TO_BASE_URL.get(port, f\"{NIM_HOST_URL_BASE}:{port}\")\n",
+    "        url = f\"{base_url}/v1/health/ready\"\n",
+    "        ready = False\n",
+    "        for attempt in range(retries):\n",
+    "            try:\n",
+    "                resp = requests.get(url, timeout=10)\n",
+    "                data = resp.json()\n",
+    "                if data.get(\"status\") == \"ready\":\n",
+    "                    print(f\"  {name} ({url}): Ready\")\n",
+    "                    ready = True\n",
+    "                    break\n",
+    "            except Exception:\n",
+    "                pass\n",
+    "            if attempt < retries - 1:\n",
+    "                print(f\"  {name}: Not ready (attempt {attempt+1}/{retries}), retrying in {delay}s...\")\n",
+    "                time.sleep(delay)\n",
+    "        if not ready:\n",
+    "            all_ready = False\n",
+    "            print(f\"  {name} ({url}): NOT READY after {retries} attempts\")\n",
+    "            if DEPLOYMENT_MODE == 'openshift':\n",
+    "                print(f\"    Troubleshoot: oc get pods -n <namespace> | grep {name.lower().replace('-', '')}\")\n",
+    "            else:\n",
+    "                print(f\"    Troubleshoot: docker ps | grep {name.lower()}\")\n",
+    "    return all_ready\n",
+    "\n",
+    "print(f\"Checking NIM health ({DEPLOYMENT_MODE} mode)...\\n\")\n",
+    "all_healthy = check_all_nims_health()\n",
+    "print(f\"\\n{'All NIMs are ready!' if all_healthy else 'Some NIMs are not ready. Check the services above.'}\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
    "source": [
     "status = check_nim_readiness(NIM_PORTS.ALPHAFOLD2_PORT.value)\n",
     "print(f\"AlphaFold2 NIM is ready: {status}\")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "status = check_nim_readiness(NIM_PORTS.PROTEINMPNN_PORT.value)\n",
     "print(f\"ProteinMPNN NIM is ready: {status}\")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "status = check_nim_readiness(NIM_PORTS.RFDIFFUSION_PORT.value)\n",
     "print(f\"RFDiffusion NIM is ready: {status}\")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "status = check_nim_readiness(NIM_PORTS.AF2_MULTIMER_PORT.value)\n",
     "print(f\"AlphaFold2-multimer NIM is ready: {status}\")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -344,9 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## estimated runtime: ~25 minutes for example 1R42 on 1 A6000 GPU\n",
     "## 12 minutes on H100 for example 1R42\n",
@@ -361,17 +493,19 @@
     "                                    nim_port=NIM_PORTS.ALPHAFOLD2_PORT.value,\n",
     "                                    echo=True\n",
     "                                    )"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Print the first two lines (160 characters) of the alphafold2 response\n",
     "alphafold2_response[0][0:160]"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -394,9 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Expected runtime: ~15 seconds to 1 minute\n",
     "## H100 runtime: 9 seconds\n",
@@ -412,17 +544,19 @@
     "    nim_endpoint=NIM_ENDPOINTS.RFDIFFUSION.value,\n",
     "    nim_port=NIM_PORTS.RFDIFFUSION_PORT.value\n",
     ")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Print the first 160 characters of the RFDiffusion PDB output\n",
     "print(rfdiffusion_response[\"output_pdb\"][0:160])"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -444,9 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Expected runtime: < 30 seconds for 20 short sequences\n",
     "## H100 Runtime: 8 seconds\n",
@@ -464,7 +596,9 @@
     "    nim_endpoint=NIM_ENDPOINTS.PROTEINMPNN.value,\n",
     "    nim_port=NIM_PORTS.PROTEINMPNN_PORT.value\n",
     ")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -475,16 +609,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fasta_sequences = [x.strip() for x in proteinmpnn_response[\"mfasta\"].split(\"\\n\") if '>' not in x][2:]\n",
     "\n",
     "binder_target_pairs = [[binder, example.target_sequence] for binder in fasta_sequences]\n",
     "\n",
     "print(f\"Generated {len(fasta_sequences)} FASTA sequences and {len(binder_target_pairs)} binder-target pairs.\")"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -506,14 +640,14 @@
   },
   {
    "cell_type": "markdown",
-   "source": "**Note:** `multimer_results` contains full PDB strings which can be several megabytes in size. Printing them in full (e.g. `print(multimer_results[0])`) may trigger an `IOPub data rate exceeded` error with default Jupyter settings. The cell below prints only the first 160 characters as a preview. See the **Jupyter Server Configuration** section above to raise the limit if you need to print the full output.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "**Note:** `multimer_results` contains full PDB strings which can be several megabytes in size. Printing them in full (e.g. `print(multimer_results[0])`) may trigger an `IOPub data rate exceeded` error with default Jupyter settings. The cell below prints only the first 160 characters as a preview. See the **Jupyter Server Configuration** section above to raise the limit if you need to print the full output."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Expected runtime: 20 min per binder-target pair.\n",
     "## Total runtime: roughly 3 hours\n",
@@ -541,19 +675,21 @@
     "    n_processed += 1\n",
     "    if n_processed >= pairs_to_process:\n",
     "        break"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Print just the first 160 characters of the first multimer response\n",
     "result_idx = 0\n",
     "prediction_idx = 0\n",
     "print(multimer_results[result_idx][prediction_idx][0:160])"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -568,9 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Function to calculate average pLDDT over all residues \n",
     "def calculate_average_pLDDT(pdb_string):\n",
@@ -595,25 +729,25 @@
     "\n",
     "    average_pLDDT = total_pLDDT / atom_count\n",
     "    return average_pLDDT\n"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plddts = []\n",
     "for idx in range(0, len(multimer_results)):\n",
     "    if multimer_results[idx] is not None:\n",
     "        plddts.append(calculate_average_pLDDT(multimer_results[idx][0]))"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Combine the results with their pLDDTs\n",
     "binder_target_results = list(zip(binder_target_pairs, multimer_results, plddts))\n",
@@ -629,7 +763,9 @@
     "    print(f\"target: {sorted_binder_target_results[i][0][1]}\")\n",
     "    print(f\"pLDDT: {sorted_binder_target_results[i][2]}\")\n",
     "    print(\"-\"*80)"
-   ]
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
**Description:**

This PR adds full OpenShift deployment support for the Protein Binder Design blueprint, validated end-to-end on a Red Hat OpenShift AI cluster. The entire deployment is declarative via Helm with no external scripts required.

**What's included:**

- `openshift.enabled` flag in the base chart values (off by default, zero impact on non-OpenShift deployments)

- `templates/openshift.yaml` — conditional template that creates OpenShift Routes (edge TLS), a custom SecurityContextConstraints (prevents SELinux relabeling on large NIM model volumes), and SCC RoleBinding for all NIM service accounts

- `templates/nim-*.yaml` — four NIM Operator templates (AlphaFold2, RFDiffusion, ProteinMPNN, AlphaFold2-Multimer) creating NIMCache + NIMService pairs, gated by `.Capabilities.APIVersions.Has` so they render only when the NIM Operator is installed

- `values-openshift.yaml` — overlay file enabling OpenShift features, disabling standard Deployments (`replicaCount: 0`), configuring GPU node tolerations, and tuning startup probes for long-running model initialization (TensorRT engine compilation, genomic database loading)

- `src/protein-binder-design.ipynb` — updated to detect `DEPLOYMENT_MODE=openshift` and automatically switch from `localhost:8081-8084` to cluster-internal K8s DNS names on port 8000; includes a keepalive thread to prevent browser disconnects during long-running predictions

- `docs/deploy-openshift.md` — full deployment runbook covering prerequisites, NIM Operator setup, Helm install, verification, and troubleshooting

**How it works:** Users deploy with a single command — Routes, SCC, NIMCache downloads, and NIMService inference servers are all managed by the chart:

```bash
helm install protein-design . \
  -f values.yaml \
  -f values-openshift.yaml \
  -n protein-design
```

The notebook runs in an RHOAI workbench with `DEPLOYMENT_MODE=openshift` set as an environment variable, connecting to the four NIMs via cluster-internal DNS.

**Validated:** Deployed and tested end-to-end on OpenShift AI cluster — all four NIMs (AlphaFold2, RFDiffusion, ProteinMPNN, AlphaFold2-Multimer) successfully cached models via NIM Operator, passed health checks, and completed the full protein binder design workflow from the RHOAI workbench: structure prediction, backbone generation, sequence design, and multimer complex prediction.